### PR TITLE
Prevent ruined towns from being rendered.

### DIFF
--- a/src/main/java/me/silverwolfg11/pl3xmaptowny/tasks/RenderTownsTask.java
+++ b/src/main/java/me/silverwolfg11/pl3xmaptowny/tasks/RenderTownsTask.java
@@ -50,6 +50,8 @@ public class RenderTownsTask extends BukkitRunnable {
         final List<TownRenderEntry> townsToRender = new ArrayList<>();
 
         for (Town town : TownyUniverse.getInstance().getTowns()) {
+            if(town.isRuined())
+                continue;
             townsToRender.add(plugin.getLayerManager().buildTownEntry(town));
             renderedTowns.remove(town.getUUID());
         }


### PR DESCRIPTION
Ruined towns would cause an NPE on the `registerReplacements` method due to the town not having a mayor, this PR fixes the issue by just ignoring any towns which are ruined.

Stacktrace of the error:
```
[05:12:09] [Server thread/WARN]: [Pl3xMap-Towny] Task #109 for Pl3xMap-Towny v1.0.0-ALPHA-2 generated an exception
java.lang.NullPointerException: null
	at me.silverwolfg11.pl3xmaptowny.managers.TownInfoManager.lambda$registerReplacements$0(TownInfoManager.java:104) ~[?:?]
	at me.silverwolfg11.pl3xmaptowny.managers.TownInfoManager.getWindowHTML(TownInfoManager.java:241) ~[?:?]
	at me.silverwolfg11.pl3xmaptowny.managers.TownInfoManager.getClickTooltip(TownInfoManager.java:228) ~[?:?]
	at me.silverwolfg11.pl3xmaptowny.managers.TownyLayerManager.buildTownEntry(TownyLayerManager.java:135) ~[?:?]
	at me.silverwolfg11.pl3xmaptowny.tasks.RenderTownsTask.run(RenderTownsTask.java:53) ~[?:?]
	at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftTask.run(CraftTask.java:100) ~[patched_1.16.5.jar:git-Airplane-"813df1a"]
	at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:468) ~[patched_1.16.5.jar:git-Airplane-"813df1a"]
	at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:1079) ~[patched_1.16.5.jar:git-Airplane-"813df1a"]
	at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:291) ~[patched_1.16.5.jar:git-Airplane-"813df1a"]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```