### PR TITLE
Fix issue when reloading on folia

### DIFF
--- a/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/MapTowny.java
+++ b/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/MapTowny.java
@@ -193,7 +193,7 @@ public final class MapTowny extends JavaPlugin implements MapTownyPlugin {
         layerManager.close();
         layerManager = new TownyLayerManager(this, mapPlatform);
         Bukkit.getPluginManager().callEvent(new MapReloadEvent()); // API Event
-        scheduler.scheduleRepeatingTask(new RenderTownsTask(this), 0, config.getUpdatePeriod() * 20L * 60);
+        scheduler.scheduleRepeatingTask(new RenderTownsTask(this), 20, config.getUpdatePeriod() * 20L * 60);
     }
 
     public void async(Runnable run) {

--- a/maptowny-plugin/src/main/resources/plugin.yml
+++ b/maptowny-plugin/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ depend: [ Towny ]
 softdepend: [ squaremap, Pl3xMap, dynmap, BlueMap ]
 authors: [ Silverwolfg11 ]
 description: A web-map addon to support Towny.
+folia-supported: true
 
 commands:
   maptowny:


### PR DESCRIPTION
Fixes town rendering breaking after reloading the plugin on folia due to a delay of 0 ticks being used, also adds a missing folia supported line to the plugin.yml