### PR TITLE
Allow empty town & capital icon urls

### DIFF
--- a/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/objects/MapConfig.java
+++ b/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/objects/MapConfig.java
@@ -236,15 +236,16 @@ public class MapConfig {
     public BufferedImage loadOutpostIcon(Logger errorLogger) {
         String url = iconInfo.outpostIconImage;
 
-        if (url.isEmpty() || url.equalsIgnoreCase("empty"))
-            return null;
-        else if (url.equalsIgnoreCase("default"))
+        if (url.equalsIgnoreCase("default"))
             url = iconInfo.townIconImage;
 
         return loadIcon("outpost", url, errorLogger);
     }
 
     private BufferedImage loadIcon(String type, String urlStr, Logger errorLogger) {
+        if (urlStr == null || "empty".equals(urlStr) || urlStr.isEmpty())
+            return null;
+
         URL url;
         try {
             url = new URL(urlStr);


### PR DESCRIPTION
The outpost icon url allows being empty to have no icon, but town and capitals did not. This allows the latter to also be empty.