### PR TITLE
Fix Bukkit scheduler being used in API methods

### DIFF
--- a/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/MapTowny.java
+++ b/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/MapTowny.java
@@ -208,4 +208,8 @@ public final class MapTowny extends JavaPlugin implements MapTownyPlugin {
     public void async(Runnable run) {
         scheduler.scheduleAsyncTask(run);
     }
+
+    public void sync(Runnable run) {
+        scheduler.scheduleTask(run);
+    }
 }

--- a/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/managers/TownyLayerManager.java
+++ b/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/managers/TownyLayerManager.java
@@ -492,7 +492,7 @@ public class TownyLayerManager implements LayerManager {
 
         if (!Bukkit.isPrimaryThread()) {
             // Can only get TRE from sync thread
-            Bukkit.getScheduler().runTask(plugin, renderTown);
+            plugin.sync(renderTown);
         }
         else {
             renderTown.run();
@@ -511,7 +511,7 @@ public class TownyLayerManager implements LayerManager {
 
         if (!Bukkit.isPrimaryThread()) {
             // Can only get TRE from sync thread
-            Bukkit.getScheduler().runTask(plugin, renderTowns);
+            plugin.sync(renderTowns);
         }
         else {
             renderTowns.run();


### PR DESCRIPTION
Using the API to re-render specific towns was failing on Folia due to the bukkit scheduler being used.