### PR TITLE
Add Nation-Towns and Ruined Icons: REVISED

### DIFF
--- a/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/managers/TownyLayerManager.java
+++ b/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/managers/TownyLayerManager.java
@@ -78,7 +78,9 @@ public class TownyLayerManager implements LayerManager {
 
     // Icon Registry Keys
     private final String TOWN_ICON = "towny_town_icon";
+    private final String NATION_ICON = "towny_nation_icon";
     private final String CAPITAL_ICON = "towny_capital_icon";
+    private final String RUINED_ICON = "towny_ruined_icon";
     private final String OUTPOST_ICON = "towny_outpost_icon";
 
     private final String TOWN_KEY_PREFIX = "town_";
@@ -182,9 +184,17 @@ public class TownyLayerManager implements LayerManager {
         if (townIcon != null)
             platform.registerIcon(TOWN_ICON, townIcon, iconHeight, iconWidth);
 
+        BufferedImage nationIcon = plugin.config().loadNationIcon(plugin.getLogger());
+        if (nationIcon != null)
+            platform.registerIcon(NATION_ICON, nationIcon, iconHeight, iconWidth);
+
         BufferedImage capitalIcon = plugin.config().loadCapitalIcon(plugin.getLogger());
         if (capitalIcon != null)
             platform.registerIcon(CAPITAL_ICON, capitalIcon, iconHeight, iconWidth);
+
+        BufferedImage ruinedIcon = plugin.config().loadRuinedIcon(plugin.getLogger());
+        if (ruinedIcon != null)
+            platform.registerIcon(RUINED_ICON, ruinedIcon, iconHeight, iconWidth);
 
         BufferedImage outpostIcon = plugin.config().loadOutpostIcon(plugin.getLogger());
         if (outpostIcon != null) {
@@ -318,7 +328,17 @@ public class TownyLayerManager implements LayerManager {
                     }
                 }
 
-                final String homeBlockIconKey = tre.isCapital() ? CAPITAL_ICON : TOWN_ICON;
+                String homeBlockIconKey = TOWN_ICON;
+                if (tre.hasNation()) {
+                    if (tre.isCapital()) {
+                        homeBlockIconKey = CAPITAL_ICON;
+                    } else {
+                        homeBlockIconKey = NATION_ICON;
+                    }
+                }
+                if (tre.isRuined()) {
+                    homeBlockIconKey = RUINED_ICON;
+                }
 
                 // Call event
                 WorldRenderTownEvent event = new WorldRenderTownEvent(worldName, tre.getTownName(), tre.getTownUUID(),
@@ -512,8 +532,14 @@ public class TownyLayerManager implements LayerManager {
         if (mapPlatform.hasIcon(TOWN_ICON))
             mapPlatform.unregisterIcon(TOWN_ICON);
 
+        if (mapPlatform.hasIcon(NATION_ICON))
+            mapPlatform.unregisterIcon(NATION_ICON);
+
         if (mapPlatform.hasIcon(CAPITAL_ICON))
             mapPlatform.unregisterIcon(CAPITAL_ICON);
+
+        if (mapPlatform.hasIcon(RUINED_ICON))
+            mapPlatform.unregisterIcon(RUINED_ICON);
 
         if (mapPlatform.hasIcon(OUTPOST_ICON))
             mapPlatform.unregisterIcon(OUTPOST_ICON);

--- a/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/objects/MapConfig.java
+++ b/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/objects/MapConfig.java
@@ -144,10 +144,20 @@ public class MapConfig {
         @Node("town-icon")
         private String townIconImage = "https://pics.freeicons.io/uploads/icons/png/20952957581537355851-512.png";
 
+        @Comment({"Icon for a town if they are in a nation. Icon must be a valid image URL.",
+                "Put 'default' to use the town icon image."})
+        @Node("nation-icon")
+        private String nationIconImage = "default";
+
         @Comment({"Icon for a town if they are the capital of the nation. Icon must be a valid image URL.",
                 "Put 'default' to use the town icon image."})
         @Node("capital-icon")
         private String capitalIconImage = "default";
+
+        @Comment({"Icon for a ruined town. Icon must be a valid image URL.",
+                "Put 'default' to use the town icon image."})
+        @Node("ruined-icon")
+        private String ruinedIconImage = "default";
 
         @Comment({"Icon for an outpost claim that will appear at the location of outpost spawns. Icon must be a valid image URL.",
                 "Put 'default' to use the town icon image.",
@@ -223,6 +233,16 @@ public class MapConfig {
     }
 
     @Nullable
+    public BufferedImage loadNationIcon(Logger errorLogger) {
+        String url = iconInfo.nationIconImage;
+
+        if (url.equalsIgnoreCase("default"))
+            url = iconInfo.townIconImage;
+
+        return loadIcon("nation", url, errorLogger);
+    }
+
+    @Nullable
     public BufferedImage loadCapitalIcon(Logger errorLogger) {
         String url = iconInfo.capitalIconImage;
 
@@ -230,6 +250,16 @@ public class MapConfig {
             url = iconInfo.townIconImage;
 
         return loadIcon("capital", url, errorLogger);
+    }
+
+    @Nullable
+    public BufferedImage loadRuinedIcon(Logger errorLogger) {
+        String url = iconInfo.ruinedIconImage;
+
+        if (url.equalsIgnoreCase("default"))
+            url = iconInfo.townIconImage;
+
+        return loadIcon("ruined", url, errorLogger);
     }
 
     @Nullable

--- a/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/objects/TownRenderEntry.java
+++ b/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/objects/TownRenderEntry.java
@@ -47,7 +47,9 @@ public class TownRenderEntry {
 
     private final UUID townUUID;
     private final String townName;
+    private final boolean nation;
     private final boolean capital;
+    private final boolean ruined;
 
     private final Color nationColor;
     private final Color townColor;
@@ -66,7 +68,9 @@ public class TownRenderEntry {
                            String clickText, String hoverText) {
         this.townUUID = town.getUUID();
         this.townName = town.getName();
+        this.nation = town.hasNation();
         this.capital = town.isCapital();
+        this.ruined = town.isRuined();
 
         this.clickText = clickText;
         this.hoverText = hoverText;
@@ -92,8 +96,16 @@ public class TownRenderEntry {
         return townName;
     }
 
+    public boolean hasNation() {
+        return nation;
+    }
+
     public boolean isCapital() {
         return capital;
+    }
+
+    public boolean isRuined() {
+        return ruined;
     }
 
     @NotNull


### PR DESCRIPTION
Simply adds more options for different icons. In the current versions of MapTowny, this functionality was not added despite being present in it's Dynmap-Towny counterpart, therefore it has been readded.

This version should significantly fix the errors of my last PR, which seemed to have messed up the comparisons due to file transfers.