### PR TITLE
Use proper optional method for town homeblock points

### DIFF
--- a/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/objects/TownRenderEntry.java
+++ b/maptowny-plugin/src/main/java/me/silverwolfg11/maptowny/objects/TownRenderEntry.java
@@ -123,7 +123,7 @@ public class TownRenderEntry {
 
     @NotNull
     public Optional<Point2D> getHomeBlockPoint() {
-        return Optional.of(homeBlockPoint);
+        return Optional.ofNullable(homeBlockPoint);
     }
 
     public boolean hasWorldBlocks() {


### PR DESCRIPTION
Somehow in 2025 it's still possible for towns to end up with no homeblocks, this PR fixes an NPE during rendering when that happens.

Closes #69